### PR TITLE
msm: vidc: Add support for Picture Order Count Type

### DIFF
--- a/drivers/video/msm/vidc/1080p/ddl/vcd_ddl.h
+++ b/drivers/video/msm/vidc/1080p/ddl/vcd_ddl.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2010-2013, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2010-2013, 2015, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -348,6 +348,7 @@ struct ddl_encoder_data{
 	u32 avc_delimiter_enable;
 	u32 vui_timinginfo_enable;
 	u32 bitstream_restrict_enable;
+	u32 pic_order_cnt_type;
 };
 struct ddl_decoder_data {
 	struct ddl_codec_data_hdr  hdr;

--- a/drivers/video/msm/vidc/1080p/ddl/vcd_ddl_properties.c
+++ b/drivers/video/msm/vidc/1080p/ddl/vcd_ddl_properties.c
@@ -1226,6 +1226,27 @@ static u32 ddl_set_enc_property(struct ddl_client_context *ddl,
 		}
 		break;
 	}
+	case VCD_I_PIC_ORDER_CNT_TYPE:
+	{
+		struct vcd_property_pic_order_cnt_type *poc =
+			(struct vcd_property_pic_order_cnt_type *)
+				property_value;
+		if (sizeof(struct vcd_property_pic_order_cnt_type) ==
+			property_hdr->sz &&
+			encoder->codec.codec == VCD_CODEC_H264 &&
+			(poc->poc_type == 0 || poc->poc_type == 2)) {
+			if (encoder->i_period.b_frames &&
+				poc->poc_type) {
+				DDL_MSG_HIGH("bframes = %d. Setting poc to 0",
+					encoder->i_period.b_frames);
+				encoder->pic_order_cnt_type = 0;
+			} else {
+				encoder->pic_order_cnt_type = poc->poc_type;
+			}
+			vcd_status = VCD_S_SUCCESS;
+		}
+		break;
+	}
 	default:
 		DDL_MSG_ERROR("%s: INVALID ID 0x%x\n", __func__,
 			(int)property_hdr->prop_id);
@@ -1826,6 +1847,15 @@ static u32 ddl_get_enc_property(struct ddl_client_context *ddl,
 			vcd_status = VCD_S_SUCCESS;
 		}
 	break;
+	case VCD_I_PIC_ORDER_CNT_TYPE:
+		if (sizeof(struct vcd_property_pic_order_cnt_type) ==
+			property_hdr->sz) {
+			((struct vcd_property_pic_order_cnt_type *)
+				property_value)->poc_type
+					= encoder->pic_order_cnt_type;
+			vcd_status = VCD_S_SUCCESS;
+		}
+		break;
 	default:
 		DDL_MSG_ERROR("%s: unknown prop_id = 0x%x", __func__,
 			property_hdr->prop_id);
@@ -1873,6 +1903,12 @@ static u32 ddl_set_enc_dynamic_property(struct ddl_client_context *ddl,
 			property_hdr->sz) {
 			encoder->i_period = *i_period;
 			dynamic_prop_change = DDL_ENC_CHANGE_IPERIOD;
+			if (encoder->i_period.b_frames &&
+				encoder->pic_order_cnt_type) {
+				DDL_MSG_HIGH("bframes = %d. Setting poc to 0",
+					encoder->i_period.b_frames);
+				encoder->pic_order_cnt_type = 0;
+			}
 			vcd_status = VCD_S_SUCCESS;
 		}
 	}

--- a/drivers/video/msm/vidc/1080p/ddl/vcd_ddl_vidc.c
+++ b/drivers/video/msm/vidc/1080p/ddl/vcd_ddl_vidc.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2010-2013, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2010-2013, 2015, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -600,7 +600,6 @@ void ddl_vidc_encode_init_codec(struct ddl_client_context *ddl)
 	const u32 recon_bufs = 4;
 	u32 h263_cpfc_enable = false;
 	u32 scaled_frame_rate, ltr_enable;
-	u32 pic_order_count = false;
 
 	ddl_vidc_encode_set_profile_level(ddl);
 	vidc_1080p_set_encode_frame_size(encoder->frame_size.width,
@@ -621,8 +620,6 @@ void ddl_vidc_encode_init_codec(struct ddl_client_context *ddl)
 		(DDL_FRAMERATE_SCALE(DDL_INITIAL_FRAME_RATE)
 		 != scaled_frame_rate))
 		h263_cpfc_enable = true;
-	if (encoder->codec.codec == VCD_CODEC_H264)
-		pic_order_count = true;
 
 	ltr_enable = DDL_IS_LTR_ENABLED(encoder);
 	DDL_MSG_HIGH("ltr_enable = %u", ltr_enable);
@@ -630,7 +627,7 @@ void ddl_vidc_encode_init_codec(struct ddl_client_context *ddl)
 		[ddl->command_channel], hdr_ext_control,
 		r_cframe_skip, false, 0,
 		h263_cpfc_enable, encoder->sps_pps.sps_pps_for_idr_enable_flag,
-		pic_order_count, encoder->closed_gop, encoder->
+		encoder->pic_order_cnt_type, encoder->closed_gop, encoder->
 		avc_delimiter_enable, encoder->vui_timinginfo_enable,
 		encoder->bitstream_restrict_enable, ltr_enable);
 	if (encoder->vui_timinginfo_enable) {

--- a/include/linux/msm_vidc_enc.h
+++ b/include/linux/msm_vidc_enc.h
@@ -515,6 +515,12 @@ struct venc_ioctl_msg{
 /*IOCTL params:GET: InputData - NULL, OutputData - venc_ltrmark.*/
 #define VEN_IOCTL_GET_LTRMARK \
 	_IOR(VEN_IOCTLBASE_ENC, 65, struct venc_ioctl_msg)
+/*IOCTL params:SET: InputData - venc_poctype, OutputData - NULL.*/
+#define VEN_IOCTL_SET_PIC_ORDER_CNT_TYPE \
+	_IOW(VEN_IOCTLBASE_ENC, 66, struct venc_ioctl_msg)
+/*IOCTL params:GET: InputData - NULL, OutputData - venc_poctype.*/
+#define VEN_IOCTL_GET_PIC_ORDER_CNT_TYPE \
+	_IOR(VEN_IOCTLBASE_ENC, 67, struct venc_ioctl_msg)
 
 struct venc_range {
 	unsigned long        max;
@@ -696,6 +702,10 @@ struct venc_ltrperiod {
 struct venc_ltruse {
 	unsigned long ltr_id;
 	unsigned long ltr_frames;
+};
+
+struct venc_poctype {
+	unsigned long poc_type;
 };
 
 #endif /* _MSM_VIDC_ENC_H_ */

--- a/include/media/msm/vcd_property.h
+++ b/include/media/msm/vcd_property.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2010-2013, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2010-2013, 2015, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -68,6 +68,7 @@
 #define VCD_I_LTR_USE (VCD_START_BASE + 0x34)
 #define VCD_I_CAPABILITY_LTR_COUNT (VCD_START_BASE + 0x35)
 #define VCD_I_LTR_MARK (VCD_START_BASE + 0x36)
+#define VCD_I_PIC_ORDER_CNT_TYPE (VCD_START_BASE + 0x37)
 
 #define VCD_START_REQ      (VCD_START_BASE + 0x1000)
 #define VCD_I_REQ_IFRAME   (VCD_START_REQ + 0x1)
@@ -445,6 +446,10 @@ struct vcd_property_ltrperiod_type {
 struct vcd_property_ltruse_type {
 	u32 ltr_id;
 	u32 ltr_frames;
+};
+
+struct vcd_property_pic_order_cnt_type {
+	u32 poc_type;
 };
 
 #endif


### PR DESCRIPTION
This patch adds POC type support for video core that
enables low-latency encoding.

Change-Id: I1fe8ea38c7ed8d203a3ef99febb4001165a856fe
Signed-off-by: Shiju Mathew shijum@codeaurora.org
